### PR TITLE
fix: save and restore AdamW optimizer state for proper training resume

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -362,6 +362,7 @@ def main():
         lr_scheduler,
         None,
         args.list_head_names,
+        optimizer=opt,  # Pass optimizer for proper resume with AdamW moments
     )
     if result is not None:
         global_step = result["global_step"]
@@ -691,6 +692,7 @@ def main():
                 global_step=global_step,
                 list_head_names=args.list_head_names,
                 keep_num=20,
+                optimizer=opt,  # Save optimizer state for proper resume
             )
             # Also save in HuggingFace format
             save_hf_checkpoint(args.output, backbone, global_step=global_step, image_size=args.image_size[0])
@@ -705,6 +707,7 @@ def main():
                 global_step=global_step,
                 list_head_names=args.list_head_names,
                 keep_num=20,
+                optimizer=opt,  # Save optimizer state for proper resume
             )
             # Also save final model in HuggingFace format
             save_hf_checkpoint(args.output, backbone, global_step=global_step, image_size=args.image_size[0])


### PR DESCRIPTION
## Summary
- Add per-rank optimizer state saving/loading to checkpoint utilities
- Fixes loss spikes and training instability when resuming from checkpoints

## Problem
The current checkpoint system saves:
- `backbone.pt` - model weights
- `scheduler.pt` - LR scheduler state
- PFC module weights per rank

But it does **NOT** save `optimizer.state_dict()`, which contains:
- `exp_avg` (1st moment / momentum)
- `exp_avg_sq` (2nd moment / RMS accumulator)
- `step` count for bias correction

When resuming training without optimizer state, AdamW starts fresh, causing:
- Transient loss spikes (especially severe if resuming mid-training with decayed LR)
- Training instability lasting 1k-10k steps (due to beta2=0.999)
- Wasted compute to recover the optimization trajectory

## Solution
- Add `optimizer` parameter to `save_checkpoint()` and `load_checkpoint()`
- Save optimizer state per-rank since it includes moments for local PFC shards
- Backward compatible: old checkpoints without `optimizer_*.pt` will warn and continue

## Files Changed
- `training/checkpoint_utils.py` - Core save/load logic
- `training/train.py` - Pass optimizer to checkpoint functions

## Testing
- Existing training should work unchanged (optimizer param defaults to None)
- New checkpoints will include `optimizer_{rank:03d}.pt` files
- Resume from new checkpoints will restore full optimizer state