### PR TITLE
docs: update skill paths to docs/issues/ subdirectory

### DIFF
--- a/.opencode/skills/issue-explainer.md
+++ b/.opencode/skills/issue-explainer.md
@@ -27,15 +27,16 @@ from the `docs/` directory.
 
 ### Phase 2: Build the Page
 
-Create `docs/issue-<N>.html` as a **single self-contained HTML file** (no build tools).
+Create `docs/issues/issue-<N>.html` as a **single self-contained HTML file** (no build tools).
 
 #### Required Structure
 
 ```
 docs/
   index.html              ← Hub page listing all issues (auto-directory)
-  issue-105.html          ← Individual explainer page
-  issue-<N>.html          ← New page you create
+  issues/
+    issue-105.html        ← Individual explainer page
+    issue-<N>.html        ← New page you create
 ```
 
 #### Design System (MUST follow)
@@ -93,7 +94,7 @@ After creating the explainer page, update `docs/index.html`:
 
 ### Phase 4: Commit
 
-- `git add docs/issue-<N>.html docs/index.html`
+- `git add docs/issues/issue-<N>.html docs/index.html`
 - Commit message format: `docs: add interactive explainer for issue #<N>`
 - Include `closes #<N>` in the commit body if appropriate
 
@@ -113,4 +114,4 @@ Draft a concise reply for the GitHub issue:
 - Code references must include actual file paths and line numbers from the codebase
 - Every formula must be KaTeX-rendered, not plain HTML entities
 - Mobile responsive — test mentally at 375px, 768px, 1024px breakpoints
-- File naming: `issue-<N>.html` where N is the GitHub issue number
+- File naming: `issues/issue-<N>.html` where N is the GitHub issue number, placed under `docs/issues/`


### PR DESCRIPTION
This pull request updates the documentation to clarify the correct location and naming convention for issue explainer HTML files. The main change is that individual issue explainer pages should now be placed in the `docs/issues/` directory instead of directly under `docs/`.

**Documentation updates for file location and naming:**

* Updated instructions to create new issue explainer files in the `docs/issues/` directory, using the `issues/issue-<N>.html` naming convention. [[1]](diffhunk://#diff-665d9cd6f9d3cb34e5d77b5858b0f060072063737b83d3900f05709fa1b0af89L30-R37) [[2]](diffhunk://#diff-665d9cd6f9d3cb34e5d77b5858b0f060072063737b83d3900f05709fa1b0af89L116-R117)
* Updated commit instructions to reference the new file path under `docs/issues/`.