### PR TITLE
Enhance explainer pages with original issue question and mobile improvements

### DIFF
--- a/.opencode/skills/issue-explainer.md
+++ b/.opencode/skills/issue-explainer.md
@@ -39,6 +39,29 @@ docs/
     issue-<N>.html        ← New page you create
 ```
 
+#### Original Issue Question (MANDATORY)
+
+Every explainer page MUST include the original issue question right after the header,
+before the first content section. Use a styled blockquote with:
+
+- Left border accent (`border-left: 4px solid var(--accent-indigo)`)
+- Link to the original GitHub issue
+- Author attribution
+- Full original question text with CN/EN translations
+- HTML structure:
+
+```html
+<div class="issue-question reveal">
+    <div class="issue-question-header">
+        💬 <a href="https://github.com/EvolvingLMMs-Lab/OneVision-Encoder/issues/<N>" target="_blank">Issue #<N></a>
+        <span class="lang-span" data-en="opened by <strong>AuthorName</strong>" data-zh="由 <strong>AuthorName</strong> 提出">...</span>
+    </div>
+    <div class="issue-question-body">
+        <!-- Original question text with lang-span translations -->
+    </div>
+</div>
+```
+
 #### Design System (MUST follow)
 
 - **White background** (`#ffffff`), clean typography
@@ -108,6 +131,7 @@ Draft a concise reply for the GitHub issue:
 ## Hard Rules
 
 - Single self-contained HTML file per issue — NO build tools, NO frameworks
+- MUST include the original issue question as a styled blockquote after the page header
 - ALL text must have CN/EN translations via `data-en`/`data-zh`
 - NO external JS libraries except KaTeX CDN
 - NO `as any`, `@ts-ignore` or type suppressions

--- a/docs/issues/issue-105.html
+++ b/docs/issues/issue-105.html
@@ -26,12 +26,14 @@
 
         * { box-sizing: border-box; margin: 0; padding: 0; }
 
+        html { scroll-behavior: smooth; }
         body {
             background: var(--bg);
             color: var(--text);
             font-family: var(--font-sans);
             line-height: 1.75;
             font-size: 16px;
+            -webkit-tap-highlight-color: transparent;
         }
 
         .container { max-width: 860px; margin: 0 auto; padding: 3rem 1.5rem 6rem; padding-top: 3.5rem; }
@@ -164,7 +166,7 @@
 
         /* Weight matrix viz */
         .weight-grid {
-            display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; margin: 1rem 0;
+            display: flex; gap: 8px; flex-wrap: nowrap; margin: 1rem 0; overflow-x: auto; padding-bottom: 0.5rem; justify-content: center;
         }
         .weight-col {
             display: flex; flex-direction: column; align-items: center; gap: 2px;
@@ -274,31 +276,49 @@
 
         /* Responsive */
         @media (max-width: 640px) {
-            h1 { font-size: 1.5rem; }
+            h1 { font-size: 1.5rem; word-break: break-word; }
             .subtitle { font-size: 1rem; }
-            .container { padding: 2rem 1rem 4rem; padding-top: 3.5rem; }
+            .container { padding: 4rem 1rem 4rem; }
+            section { margin-bottom: 2.5rem; }
+            .issue-question { padding: 1rem 1.25rem; font-size: 0.9rem; }
             .flow-h { flex-direction: column; align-items: center; }
-            .flow-box { min-width: 0; width: 100%; }
+            .flow-box { min-width: 0; width: 100%; word-break: break-word; }
             .arrow-r { width: 0; height: 24px; border-top: none; border-left: 1.5px solid var(--border-strong); }
             .arrow-r::after { right: auto; top: auto; bottom: -1px; left: -5px; border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 7px solid var(--border-strong); border-bottom: none; }
             .arrow-r.animated::before { display: none; }
+            .arrow-d-container { margin-left: 0 !important; text-align: center; }
+            .arrow-d { margin: 0 auto !important; }
             .pfc-stage { flex-direction: column; }
-            .pfc-stage-label { width: auto; text-align: left; padding-top: 0; }
+            .pfc-stage-label { width: auto; text-align: left; padding: 0.25rem 0 0.5rem 0.5rem; border-left: 3px solid var(--accent-indigo); }
             .stat-row { flex-direction: column; }
             .stat-card { min-width: 0; }
             .arch-branches { flex-direction: column; }
-            .arch-branch { min-width: 0; }
-            table { display: block; overflow-x: auto; -webkit-overflow-scrolling: touch; }
-            pre { font-size: 0.75rem; padding: 1rem; }
+            .arch-branch { min-width: 0; padding: 1rem; }
+            .arch-branch code { font-size: 0.7rem; word-break: break-all; }
+            table { display: block; overflow-x: auto; -webkit-overflow-scrolling: touch; font-size: 0.8rem; }
+            th, td { padding: 0.5rem; }
+            pre { font-size: 0.75rem; padding: 1rem; overflow-x: auto; }
             .formula { padding: 1rem; overflow-x: auto; }
             .formula .katex { font-size: 1em; }
-            .loss-row { gap: 4px; }
-            .loss-box { padding: 4px 8px; font-size: 0.7rem; }
-            .loss-plus { font-size: 1rem; }
-            .weight-grid { gap: 4px; }
+            .loss-row { gap: 4px; justify-content: center; }
+            .loss-box { padding: 4px 6px; font-size: 0.65rem; word-break: break-all; }
+            .loss-plus { font-size: 0.85rem; margin: 0 2px; }
+            .weight-grid { gap: 2px; overflow-x: auto; padding-bottom: 0.5rem; justify-content: flex-start; }
+            .weight-col-label { font-size: 0.6rem; padding: 2px 4px; }
+            .weight-cell { width: 10px; height: 10px; }
             .arcface-anim .card { padding: 1rem; }
+            .arcface-anim .card > div { flex-direction: column; }
+            .arcface-anim canvas { max-width: 100%; height: auto; }
+            .tag-row { max-height: 200px; overflow-y: auto; border: 1px solid var(--border); border-radius: 6px; padding: 6px; }
+            .tag-row#tag-row-8 { max-height: none; overflow-y: visible; border: none; padding: 0; }
+            .tag { padding: 6px 12px; font-size: 0.75rem; }
+            #af-tabs { grid-template-columns: repeat(4, 1fr); }
+            .af-tab { padding: 10px 0 !important; }
+            .arch-backbone { font-size: 0.95rem; word-break: break-word; }
+            .arch-backbone .sub { font-size: 0.75rem; display: block; line-height: 1.4; margin-top: 0.25rem; }
+            .arch-connectors { display: none; }
             .lang-toggle { padding: 6px 4px; }
-            .lang-toggle-btn { padding: 6px 16px; font-size: 0.85rem; }
+            .lang-toggle-btn { padding: 10px 16px; font-size: 0.85rem; min-height: 44px; display: flex; align-items: center; }
         }
     
         /* Language Toggle */
@@ -431,7 +451,7 @@
                 </div>
             </div>
 
-            <div style="margin:0.5rem 0 0.5rem 112px;"><div class="arrow-d"></div></div>
+            <div class="arrow-d-container" style="margin: 0.5rem 0 0.5rem 112px;"><div class="arrow-d"></div></div>
 
             <!-- Step 2: Random sample 8 -->
             <div class="pfc-stage">
@@ -448,7 +468,7 @@ local_labels = torch.<span class="fn">gather</span>(local_labels, dim=<span clas
                 </div>
             </div>
 
-            <div style="margin:0.5rem 0 0.5rem 112px;"><div class="arrow-d"></div></div>
+            <div class="arrow-d-container" style="margin: 0.5rem 0 0.5rem 112px;"><div class="arrow-d"></div></div>
 
             <!-- Step 3: 8 independent classifiers -->
             <div class="pfc-stage">
@@ -468,10 +488,10 @@ local_labels = torch.<span class="fn">gather</span>(local_labels, dim=<span clas
                             <span class="lang-span" data-en="Multi-label ArcFace Visualization" data-zh="多标签 ArcFace 可视化">Multi-label ArcFace Visualization</span>
                         </h4>
                         <div style="display: flex; flex-wrap: wrap; gap: 1.5rem; align-items: center;">
-                            <div style="flex: 1 1 50%; min-width: 250px; text-align: center; position: relative;">
+                            <div style="flex: 1 1 100%; min-width: 0; text-align: center; position: relative;">
                                 <canvas id="af-canvas" width="400" height="400" style="max-width: 100%; height: auto; display: block; margin: 0 auto;"></canvas>
                             </div>
-                            <div style="flex: 1 1 40%; min-width: 220px; display: flex; flex-direction: column; gap: 1rem;">
+                            <div style="flex: 1 1 100%; min-width: 0; display: flex; flex-direction: column; gap: 1rem;">
                                 <div>
                                     <div style="font-size: 0.85rem; color: var(--text-muted); margin-bottom: 0.5rem; display: flex; justify-content: space-between;">
                                         <span class="lang-span" data-en="Click to select label" data-zh="点击选择标签">Click to select label</span>
@@ -487,7 +507,7 @@ local_labels = torch.<span class="fn">gather</span>(local_labels, dim=<span clas
                                     <div><strong>θ + m (margin):</strong> <span id="af-info-margin">0°</span></div>
                                     <div><strong><span class="lang-span" data-en="Sampled negatives" data-zh="采样的负类">Sampled negatives</span>:</strong> <span style="color: var(--text-muted);">5 / 36K</span></div>
                                 </div>
-                                <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; font-size: 0.8rem; color: var(--text-muted); margin-top: 0.5rem;">
+                                <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; font-size: 0.8rem; color: var(--text-muted); margin-top: 0.5rem; justify-content: center;">
                                     <div style="display: flex; align-items: center; gap: 4px;"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:#2563eb;"></span> <span class="lang-span" data-en="Embedding" data-zh="嵌入向量">Embedding</span></div>
                                     <div style="display: flex; align-items: center; gap: 4px;"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:#e11d48;"></span> <span class="lang-span" data-en="Positive center" data-zh="正类中心">Positive center</span></div>
                                     <div style="display: flex; align-items: center; gap: 4px;"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:#94a3b8;"></span> <span class="lang-span" data-en="Negative center" data-zh="负类中心">Negative center</span></div>
@@ -696,7 +716,7 @@ local_labels = torch.<span class="fn">gather</span>(local_labels, dim=<span clas
                 </div>
             </div>
 
-            <div style="margin:0.5rem 0 0.5rem 112px;"><div class="arrow-d"></div></div>
+            <div class="arrow-d-container" style="margin: 0.5rem 0 0.5rem 112px;"><div class="arrow-d"></div></div>
 
             <!-- Step 4: Average loss -->
             <div class="pfc-stage">

--- a/docs/issues/issue-105.html
+++ b/docs/issues/issue-105.html
@@ -249,6 +249,24 @@
         .callout.emerald { border-color: var(--accent-emerald); }
         .callout p:last-child { margin-bottom: 0; }
 
+        /* Original Issue Question */
+        .issue-question {
+            background: var(--bg-alt); border: 1px solid var(--border);
+            border-left: 4px solid var(--accent-indigo); border-radius: 0 10px 10px 0;
+            padding: 1.5rem 1.75rem; margin-bottom: 3rem;
+        }
+        .issue-question-header {
+            display: flex; align-items: center; gap: 8px; margin-bottom: 0.75rem;
+            font-size: 0.85rem; color: var(--text-muted);
+        }
+        .issue-question-header a {
+            color: var(--accent-indigo); text-decoration: none; font-weight: 600;
+        }
+        .issue-question-header a:hover { text-decoration: underline; }
+        .issue-question-body { font-size: 0.95rem; color: var(--text); line-height: 1.7; }
+        .issue-question-body ul { margin: 0.5rem 0; padding-left: 1.25rem; }
+        .issue-question-body li { margin-bottom: 0.25rem; }
+
         /* Table */
         table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: 0.9rem; }
         th, td { padding: 0.6rem 0.75rem; text-align: left; border-bottom: 1px solid var(--border); }
@@ -332,6 +350,29 @@
         <h1><span class="lang-span" data-en="How OCR Training Works in OneVision-Encoder" data-zh="OneVision-Encoder 中 OCR 训练的工作原理">How OCR Training Works in OneVision-Encoder</span></h1>
         <p class="subtitle"><span class="lang-span" data-en="Explaining multi-label Partial FC for OCR-based supervision" data-zh="解析基于 OCR 监督的多标签 Partial FC 机制">Explaining multi-label Partial FC for OCR-based supervision</span></p>
     </header>
+
+    <!-- Original Issue Question -->
+    <div class="issue-question reveal">
+        <div class="issue-question-header">
+            💬 <a href="https://github.com/EvolvingLMMs-Lab/OneVision-Encoder/issues/105" target="_blank">Issue #105</a>
+            <span class="lang-span" data-en="opened by &lt;strong&gt;JerryPW&lt;/strong&gt;" data-zh="由 &lt;strong&gt;JerryPW&lt;/strong&gt; 提出">opened by <strong>JerryPW</strong></span>
+        </div>
+        <div class="issue-question-body">
+            <p><span class="lang-span"
+                data-en="Hi, thank you for releasing this excellent work. While reading the paper, there seems to be one point that is still unclear: &lt;strong&gt;how the OCR annotations are actually incorporated into training.&lt;/strong&gt;"
+                data-zh="你好，感谢你们发布这项出色的工作。在阅读论文时，有一个点似乎仍不清楚：&lt;strong&gt;OCR 标注究竟是如何纳入训练的。&lt;/strong&gt;">Hi, thank you for releasing this excellent work. While reading the paper, there seems to be one point that is still unclear: <strong>how the OCR annotations are actually incorporated into training.</strong></span></p>
+            <p><span class="lang-span" data-en="From the paper, the following part is understood:" data-zh="从论文中，以下部分是已知的：">From the paper, the following part is understood:</span></p>
+            <ul>
+                <li><span class="lang-span" data-en="PaddleOCR is applied to images from OBELICS and Zero250M" data-zh="对 OBELICS 和 Zero250M 的图像使用 PaddleOCR">PaddleOCR is applied to images from OBELICS and Zero250M</span></li>
+                <li><span class="lang-span" data-en="The recognized text is tokenized" data-zh="识别出的文本被分词">The recognized text is tokenized</span></li>
+                <li><span class="lang-span" data-en="100 fine-grained tags are constructed for each image" data-zh="为每张图构建 100 个细粒度标签">100 fine-grained tags are constructed for each image</span></li>
+                <li><span class="lang-span" data-en="OCR data is introduced in Stage 2 together with video supervision" data-zh="OCR 数据在 Stage 2 与视频监督一起引入">OCR data is introduced in Stage 2 together with video supervision</span></li>
+            </ul>
+            <p><span class="lang-span"
+                data-en="However, the paper does not seem to explicitly describe how these OCR-derived tags are optimized in the training objective."
+                data-zh="然而，论文似乎没有明确描述这些 OCR 标签在训练目标中是如何优化的。">However, the paper does not seem to explicitly describe how these OCR-derived tags are optimized in the training objective.</span></p>
+        </div>
+    </div>
 
     <!-- Section 1: Overview -->
     <section class="reveal">


### PR DESCRIPTION
This pull request improves the documentation and user experience for issue explainer pages, focusing on standardizing the inclusion and styling of the original issue question and enhancing mobile responsiveness and accessibility. The most significant changes are the addition of a mandatory, styled "Original Issue Question" block to explainer pages, updates to the documentation to reflect this requirement, and a series of CSS and HTML adjustments for better layout and usability on different devices.

**Documentation and Content Requirements:**
- Added a mandatory section for the "Original Issue Question" in every explainer page, specifying required HTML structure, styling, and bilingual support (EN/CN). This block must appear right after the header and before any content. (`.opencode/skills/issue-explainer.md`)
- Updated the "Hard Rules" to explicitly require inclusion of the original issue question as a styled blockquote after the page header. (`.opencode/skills/issue-explainer.md`)

**Implementation in Issue Page:**
- Implemented the new "issue-question" block in `issue-105.html`, including the GitHub link, author attribution, and bilingual question text, following the documented structure and style. (`docs/issues/issue-105.html`)

**Styling and Responsiveness Improvements:**
- Added and refined CSS for the new "issue-question" block, including accent border, background, and responsive padding/font-size adjustments. Improved mobile responsiveness for multiple components, such as tables, code blocks, flow diagrams, and visualization containers. (`docs/issues/issue-105.html`)
- Improved horizontal scrolling and layout for weight matrix visualizations and other flex containers, especially on mobile devices. (`docs/issues/issue-105.html`)
- Enhanced the layout of visualization and flow diagram elements for better alignment and usability on smaller screens, including adjustments to arrow containers and flexbox properties. (`docs/issues/issue-105.html`) [[1]](diffhunk://#diff-981cbde82de91217cc4765e36c034c4460d15b3a92a7ba47da05b7dc593906d1L393-R454) [[2]](diffhunk://#diff-981cbde82de91217cc4765e36c034c4460d15b3a92a7ba47da05b7dc593906d1L410-R471) [[3]](diffhunk://#diff-981cbde82de91217cc4765e36c034c4460d15b3a92a7ba47da05b7dc593906d1L430-R494) [[4]](diffhunk://#diff-981cbde82de91217cc4765e36c034c4460d15b3a92a7ba47da05b7dc593906d1L449-R510) [[5]](diffhunk://#diff-981cbde82de91217cc4765e36c034c4460d15b3a92a7ba47da05b7dc593906d1L658-R719)