### PR TITLE
fix: support older ffmpeg (libavformat < 59) in cv-reader

### DIFF
--- a/llava_next/Compressed_Video_Reader/src/cv_reader/h264_api.cpp
+++ b/llava_next/Compressed_Video_Reader/src/cv_reader/h264_api.cpp
@@ -531,7 +531,11 @@ static PyObject *decode_h264(AVFormatContext *fmt_ctx, bool with_residual, int m
     int ret;
     AVStream *st;
     AVCodecContext *dec_ctx = nullptr;
+    #if LIBAVFORMAT_VERSION_MAJOR >= 59
     const AVCodec *dec = nullptr;
+#else
+    AVCodec *dec = nullptr;
+#endif
     AVDictionary *opts = nullptr;
     AVPacket *pkt = nullptr;
     AVFrame *frame = nullptr;
@@ -622,7 +626,11 @@ static PyObject *decode_h264_cb(AVFormatContext *fmt_ctx,
     int ret;
     AVStream *st;
     AVCodecContext *dec_ctx = nullptr;
+    #if LIBAVFORMAT_VERSION_MAJOR >= 59
     const AVCodec *dec = nullptr;
+#else
+    AVCodec *dec = nullptr;
+#endif
     AVDictionary *opts = nullptr;
     AVPacket *pkt = nullptr;
     AVFrame *frame = nullptr;


### PR DESCRIPTION
The cv-reader build fails on Ubuntu 22.04 which ships with ffmpeg 4.4 (libavformat 58.x).

In ffmpeg 5.0+ (libavformat 59+), `AVCodec` became const-qualified in `av_find_best_stream()`. This PR adds a version check to support both old and new ffmpeg APIs.

Fixes build error:
```
error: cannot convert 'const AVCodec**' to 'AVCodec**'
```